### PR TITLE
Add >= to enforced node version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@types/react-helmet": "^6.1.5"
       },
       "engines": {
-        "node": "16.14.2"
+        "node": ">=16.14.2"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "extends": "react-app"
   },
   "engines": {
-    "node": "16.14.2"
+    "node": ">=16.14.2"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
I believe this is an oversight.

```
$ npm i
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'laulum.me-new@0.1.0',
npm WARN EBADENGINE   required: { node: '16.14.2' },
npm WARN EBADENGINE   current: { node: 'v16.17.1', npm: '8.3.1' }
npm WARN EBADENGINE }
```