### PR TITLE
feat(security): enforce strict markdown sanitization in song rendering

### DIFF
--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -1,0 +1,52 @@
+import { unified } from "unified";
+import remarkGfm from "remark-gfm";
+import remarkHtml from "remark-html";
+import remarkParse from "remark-parse";
+
+const STRICT_SANITIZE_SCHEMA = {
+  tagNames: [
+    "a",
+    "blockquote",
+    "br",
+    "code",
+    "del",
+    "em",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "hr",
+    "li",
+    "ol",
+    "p",
+    "pre",
+    "strong",
+    "table",
+    "tbody",
+    "td",
+    "th",
+    "thead",
+    "tr",
+    "ul",
+  ],
+  attributes: {
+    a: ["href", "title"],
+  },
+  protocols: {
+    href: ["http", "https"],
+  },
+};
+
+export const renderMarkdownToSafeHtml = async (markdown: string) => {
+  const processedContent = await unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .use(remarkHtml, {
+      sanitize: STRICT_SANITIZE_SCHEMA,
+    })
+    .process(markdown);
+
+  return processedContent.toString();
+};

--- a/pages/songs/[slug].tsx
+++ b/pages/songs/[slug].tsx
@@ -1,9 +1,5 @@
 import type { GetStaticProps, InferGetStaticPropsType } from "next";
 import Head from "next/head";
-import { unified } from "unified";
-import remarkParse from "remark-parse";
-import remarkHtml from "remark-html";
-import remarkGfm from "remark-gfm";
 
 import { Footer, Header, Link } from "@/components";
 
@@ -13,6 +9,7 @@ import slugify from "@/lib/slugify";
 import { Song } from "@/types/song";
 import { useEffect, useState } from "react";
 import { getBookNames } from "@/lib/books";
+import { renderMarkdownToSafeHtml } from "@/lib/markdown";
 
 import markdownStyles from "./markdown.module.css";
 
@@ -43,13 +40,7 @@ export const getStaticProps: GetStaticProps<{
 
   const bookNames = await getBookNames();
 
-  const processedContent = await unified()
-    .use(remarkGfm)
-    .use(remarkParse)
-    .use(remarkHtml)
-    .process(song.lyrics);
-
-  const markdownHtml = processedContent.toString();
+  const markdownHtml = await renderMarkdownToSafeHtml(song.lyrics);
 
   return { props: { markdownHtml, song, bookNames } };
 };


### PR DESCRIPTION
## Summary
- move song markdown rendering into a dedicated helper to centralize security-sensitive HTML generation
- enforce an explicit strict sanitize schema so only a narrow, markdown-focused set of tags and attributes is rendered
- restrict rendered link protocols to `http` and `https` to prevent unsafe URL schemes before HTML is injected

## Validation
- run `npm run lint` (passes; existing Next.js config warning remains unrelated to this change)